### PR TITLE
Links, include end polymorphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This guide is referred in all public and private Pull Requests / code reviews.
   *  [Standard timestamps](#standard-timestamps)
   *  [UTC times formatted in ISO8601](#utc-times-formatted-in-iso8601)
   *  [Nested foreign key relations](#nested-foreign-key-relations)
+  *  [Include](#include)  
   *  [Show rate limit status](#show-rate-limit-status)
   *  [JSON minified in all responses](#json-minified-in-all-responses)
 
@@ -381,7 +382,41 @@ or introduce more top-level response fields, e.g.:
   // ...
 }
 ```
+#### Include
 
+When possible the Gild API expose an **include** parameter of type Array. This is intended to extend the response including the full representation of a related object or other information that are not directly part of the returned resource.
+
+``bash
+$ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef
+
+{
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "name": "name",
+  "company": {
+    	"id": "01234567-89ab-cdef-0123-456789abcdef"
+  },
+  ...
+}
+``
+Including the full company resource:
+
+``bash
+$ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef?include[]=company
+
+{
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "name": "name",
+  "company": {
+    	"id": "01234567-89ab-cdef-0123-456789abcdef",
+    	"domain" : "example.com",
+    	"name" : "Example Ltd"
+    	........
+  },
+  ...
+}
+``
+For performance reason the Gild API is likely to accept less include request when returning a collection.
+ 
 #### Rate limit status
 
 The Gild API has a rate limit for requests from clients to protect the health of the service

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This guide is referred in all public and private Pull Requests / code reviews.
   *  [UTC times formatted in ISO8601](#utc-times-formatted-in-iso8601)
   *  [Nested foreign key relations](#nested-foreign-key-relations)
   *  [Include](#include)  
+  *  [Polymorphic entities](#polymorphic-entities)  
   *  [Show rate limit status](#show-rate-limit-status)
   *  [JSON minified in all responses](#json-minified-in-all-responses)
 
@@ -322,12 +323,15 @@ Content-Type: application/json;charset=utf-8
   "created_at": "2012-01-01T12:00:00Z",
   "id": "01234567-89ab-cdef-0123-456789abcdef",
   "links" : {
-  	"self" : "https://service.com/users/01234567-89ab-cdef-0123-456789abcdef"  }
+  	"self" : "https://service.com/users/01234567-89ab-cdef-0123-456789abcdef"
+  }
   "company" : {
   	 "id": "01234567-89ab-cdef-0123-764568abghtr",
   	 "links" : {
   	    "self" : "https://service.com/companie/01234567-89ab-cdef-0123-764568abghtr"
-      }  	  }	 ................ 
+      }  	
+  }	
+ ................ 
 }
 ```
 The **self** link is always exposed when a resource can be retrieved  by the API. The links section can be used to expose more API services related to the resource.
@@ -410,9 +414,10 @@ or introduce more top-level response fields, e.g.:
 ```
 #### Include
 
-When possible the Gild API expose an **include** parameter of type Array. This is intended to extend the response including the full representation of a related object or other information that are not directly part of the returned resource.
+When possible the Gild API exposes the **include** parameter of type Array. 
+This is intended to extend the response including the full representation of a related resource object or other information that are not directly part of the returned resource.
 
-``bash
+```bash
 $ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef
 
 {
@@ -423,10 +428,10 @@ $ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef
   },
   ...
 }
-``
+```
 Including the full company resource:
 
-``bash
+```bash
 $ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef?include[]=company
 
 {
@@ -440,8 +445,40 @@ $ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef?inc
   },
   ...
 }
+```
+For performance reason the Gild API is likely to accept less include request when returning a resource collection.
+
+#### Polymorphic entities
+
+Polymorphic entities will expose a **parent** section where they declare their own specific parent relation.
+
+``bash
+$ curl -X GET https://service.com/users/01234567-89ab-cdef-0123-456789abcdef/attachments
+
+[{
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "filename": "test.pdf",
+  "parent": {
+     "type": "documents"
+    	 "id": "01234567-89ab-cdef-0123-456789abcdef"
+    	 "links" : {
+    	 	"self" : "https://service.com/documents/01234567-89ab-cdef-0123-456789abcdef/attachment/01234567-89ab-cdef-0123-456789abcdef"
+    	 }
+  },
+  {
+  	
+  "id": "01234567-89ab-cdef-0123-456789ghtyrt",
+  "filename": "test.pdf",
+  "parent": {
+     "type": "comments"
+    	 "id": "01234567-89ab-cdef-0123-987645vgtbshr"
+    	 "links" : {
+    	 	"self" : "https://service.com/comments/01234567-89ab-cdef-0123-987645vgtbsh/attachment/01234567-89ab-cdef-0123-456789ghtyrt"
+    	 }
+  },
+  ...
+}]
 ``
-For performance reason the Gild API is likely to accept less include request when returning a collection.
  
 #### Rate limit status
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This guide is referred in all public and private Pull Requests / code reviews.
   *  [Status codes](#status-codes)
   *  [Response Content Types](#response-content-types)
   *  [Full resources where available](#full-resources-where-available)
+  *  [Links section](#links-section)
   *  [Resource (UU)IDs](#resource-uuids)
   *  [Standard timestamps](#standard-timestamps)
   *  [UTC times formatted in ISO8601](#utc-times-formatted-in-iso8601)
@@ -306,6 +307,31 @@ Content-Type: application/json;charset=utf-8
 ...
 {}
 ```
+
+#### Links section
+
+Every resource returned by the Gild API include a **links** section.
+
+```bash
+$ curl -X GET  https://service.com/users/ 01234567-89ab-cdef-0123-456789abcdef
+
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+...
+{
+  "created_at": "2012-01-01T12:00:00Z",
+  "id": "01234567-89ab-cdef-0123-456789abcdef",
+  "links" : {
+  	"self" : "https://service.com/users/01234567-89ab-cdef-0123-456789abcdef"  }
+  "company" : {
+  	 "id": "01234567-89ab-cdef-0123-764568abghtr",
+  	 "links" : {
+  	    "self" : "https://service.com/companie/01234567-89ab-cdef-0123-764568abghtr"
+      }  	  }	 ................ 
+}
+```
+The **self** link is always exposed when a resource can be retrieved  by the API. The links section can be used to expose more API services related to the resource.
+
 
 #### Resource (UU)IDs
 


### PR DESCRIPTION
This PR add some specification about the following issues:

* Use of the **include** param. The client may ask for a full representation of a related object or for more information that a specific endpoint may include.
* Resource **links** section. This include a **self** link any time that a resource can be retrieved individually and any other link (Eg: actions) related to the resource itself.
* Polymorphic entities **parent** declaration.  

cc @stefanoc @tejo @liquid1982 @taganaka @openmosix 